### PR TITLE
Switch CSVW git dependency to npm release

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "xlsx": "^0.11.3"
   },
   "devDependencies": {
-    "mocha": "^3.5.0",
+    "mocha": "^7.0.0",
     "rdf-ext": "^1.0.0",
     "standard": "^10.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/rdf-ext/rdf-parser-csvw-xlsx",
   "dependencies": {
     "lodash": "^4.17.4",
-    "rdf-parser-csvw": "git://github.com/rdf-ext/rdf-parser-csvw.git#develop",
+    "rdf-parser-csvw": "^0.13.0",
     "rdf-parser-jsonld": "^1.0.1",
     "readable-stream": "^2.3.3",
     "xlsx": "^0.11.3"


### PR DESCRIPTION
There are two sec-vulnerabilities open which npm could not fix automatically, I think it's around mocha.